### PR TITLE
Fixed problem with docker cp's path

### DIFF
--- a/build_core.sh
+++ b/build_core.sh
@@ -2,6 +2,6 @@
 echo "Building core ISLANDORA on $1";
 docker exec -it $1_solr_1 mkdir -p /opt/solr/server/solr/ISLANDORA
 docker exec -it $1_solr_1 mkdir /opt/solr/server/solr/configsets
-docker cp ~/Downloads/conf/  $1_solr_1:/opt/solr/server/solr/ISLANDORA
+docker cp ./conf/  $1_solr_1:/opt/solr/server/solr/ISLANDORA
 docker exec -it  $1_solr_1 chown -R solr:solr /opt/solr/server/solr/ISLANDORA
 docker exec -it  $1_solr_1 /opt/solr/bin/solr create_core -c ISLANDORA -d /opt/solr/server/solr/ISLANDORA/conf -force


### PR DESCRIPTION
On line 5, the script tries to copy from ~/Downloads/conf which is a non-existing directory by default and seems to be a mistake. There is a .conf in the repository directory which I believe would be correct rather than ~/Downloads/conf